### PR TITLE
Add animated pelican SVG to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,38 @@ def hello():
 
 > 当思绪随指尖滑落，代码亦成诗行。
 
+<svg width="320" height="180" viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="骑着自行车的鹈鹕">
+  <style>
+    .wheel { stroke: #222; stroke-width: 4; fill: none; }
+    .pedal { stroke: #f8a100; stroke-width: 4; }
+    .leg { stroke: #f1c27d; stroke-width: 5; stroke-linecap: round; }
+    .wing { fill: #f2f2f2; stroke: #c4c4c4; stroke-width: 2; }
+    .body { fill: #ffffff; stroke: #c4c4c4; stroke-width: 2; }
+    .beak { fill: #f8a100; stroke: #c97200; stroke-width: 2; }
+    .eye { fill: #111; }
+    .pedal-group { transform-origin: 170px 105px; animation: pedal 2s linear infinite; }
+    .wheel-spin { transform-origin: center; animation: wheel 2s linear infinite; }
+    @keyframes pedal { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+    @keyframes wheel { from { transform: rotate(0deg); } to { transform: rotate(-360deg); } }
+  </style>
+  <rect width="320" height="180" fill="#f9fbff"/>
+  <circle class="wheel wheel-spin" cx="110" cy="130" r="35"/>
+  <circle class="wheel wheel-spin" cx="210" cy="130" r="35"/>
+  <line x1="110" y1="130" x2="170" y2="105" stroke="#333" stroke-width="4"/>
+  <line x1="170" y1="105" x2="210" y2="130" stroke="#333" stroke-width="4"/>
+  <line x1="170" y1="105" x2="200" y2="75" stroke="#333" stroke-width="4"/>
+  <g class="pedal-group">
+    <line class="pedal" x1="170" y1="105" x2="190" y2="105"/>
+    <circle fill="#f8a100" cx="170" cy="105" r="6"/>
+  </g>
+  <path class="body" d="M180 65 Q210 60 215 80 Q220 110 180 115 Q140 110 145 80 Q150 60 180 65 Z"/>
+  <path class="wing" d="M165 75 Q130 85 125 110 Q150 105 170 95"/>
+  <ellipse class="body" cx="210" cy="90" rx="28" ry="18"/>
+  <path class="beak" d="M238 85 Q270 80 270 90 Q270 100 238 95 Z"/>
+  <circle class="eye" cx="225" cy="82" r="3"/>
+  <line class="leg" x1="175" y1="110" x2="150" y2="140"/>
+  <line class="leg" x1="185" y1="112" x2="205" y2="140"/>
+  <text x="20" y="30" font-size="16" fill="#7a869a">鹈鹕骑着清晨的风</text>
+</svg>
+
 [^1]: 人生海海，代码亦是旅途。


### PR DESCRIPTION
## Summary
- embed a playful SVG illustration of a pelican riding a bicycle before the footnotes
- include simple CSS animations to spin the wheels and pedals for a lively effect

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d4f2c54a0832088e7dd7cad4fb985)